### PR TITLE
Add Promotions classes

### DIFF
--- a/src/GroceryCo.Checkout.Tests/GroceryCo.Checkout.Tests.csproj
+++ b/src/GroceryCo.Checkout.Tests/GroceryCo.Checkout.Tests.csproj
@@ -54,7 +54,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Model\FixedPricePromotionTests.cs" />
     <Compile Include="Model\GroceryItemLoaderTests.cs" />
+    <Compile Include="Model\PromotionLoaderTests.cs" />
+    <Compile Include="Model\RelativePricePromotionTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GroceryCo.Checkout.Tests/Model/FixedPricePromotionTests.cs
+++ b/src/GroceryCo.Checkout.Tests/Model/FixedPricePromotionTests.cs
@@ -1,0 +1,30 @@
+﻿using GroceryCo.Checkout.Model;
+using NUnit.Framework;
+
+namespace GroceryCo.Checkout.Tests.Model
+{
+    internal static class FixedPricePromotionTests
+    {
+        [TestCaseSource(nameof(TestCases))]
+        public static void Price_VariousScenarios_PriceComputedCorrectly(int quantity, decimal rate)
+        {
+            // Arrange
+            var promotion = new FixedPricePromotion(quantity, rate);
+
+            // Act
+            var actualPrice = promotion.Price;
+
+            //Assert
+            Assert.That(actualPrice, Is.EqualTo(rate));
+        }
+
+
+        private static readonly TestCaseData[] TestCases = new[]
+        {
+            new TestCaseData(2, 3.0m)
+                .SetName("Two for $3"),
+            new TestCaseData(3, 3.0m)
+                .SetName("Three for $3")
+        };
+    }
+}

--- a/src/GroceryCo.Checkout.Tests/Model/PromotionLoaderTests.cs
+++ b/src/GroceryCo.Checkout.Tests/Model/PromotionLoaderTests.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GroceryCo.Checkout.Model;
+using Newtonsoft.Json;
+using NUnit.Framework;
+
+namespace GroceryCo.Checkout.Tests.Model
+{
+    internal static class PromotionLoaderTests
+    {
+        [Test]
+        public static void Load_ValidJson_Succeeds()
+        {
+            // Arrange + Act
+            var promotions = PromotionLoader.Load(ValidPromotionsJson, StockItems).ToArray();
+
+            //Assert
+            Assert.That(promotions.Length, Is.EqualTo(1));
+
+            var promotion = promotions.First();
+
+            // Two items for the price of one
+            Assert.That(promotion.Quantity, Is.EqualTo(2));
+            Assert.That(promotion.Price, Is.EqualTo(1.0m));
+        }
+
+
+        [Test]
+        public static void Load_InvalidJson_Fails()
+        {
+            // Arrange + Act + Assert
+            Assert.Throws<JsonSerializationException>(() => PromotionLoader.Load(InvalidPromotionsJson, StockItems));
+        }
+
+
+        private static readonly IDictionary<string, GroceryItem> StockItems = new Dictionary<string, GroceryItem>
+        {
+            {
+                "Apple",
+                new GroceryItem {Id = "Apple", Price = 1.0m}
+            }
+        };
+
+
+        private const string ValidPromotionsJson = "[{'itemId': 'Apple', 'quantity': 2, 'rate': 0.5, 'promotionType': 'relative'}]";
+
+
+        private const string InvalidPromotionsJson = "{'foo': 'bar'}";
+    }
+}

--- a/src/GroceryCo.Checkout.Tests/Model/RelativePricePromotionTests.cs
+++ b/src/GroceryCo.Checkout.Tests/Model/RelativePricePromotionTests.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using GroceryCo.Checkout.Model;
+using NUnit.Framework;
+
+namespace GroceryCo.Checkout.Tests.Model
+{
+    internal static class RelativePricePromotionTests
+    {
+        [TestCaseSource(nameof(TestCases))]
+        public static void Price_VariousScenarios_TotalPriceComputedCorrectly(int quantity, decimal rate, GroceryItem groceryItem, decimal expectedPrice)
+        {
+            // Arrange
+            var promotion = new RelativePricePromotion(groceryItem, quantity, rate);
+
+            // Act
+            var actualPrice = promotion.Price;
+
+            // Assert
+            Assert.That(actualPrice, Is.EqualTo(expectedPrice));
+        }
+
+
+        private static readonly GroceryItem TestItem = new GroceryItem {Id = "Apples", Price = 1.0m};
+
+
+        private static readonly TestCaseData[] TestCases = new []
+        {
+            new TestCaseData(2, 0.75m,TestItem, 1.5m)
+                .SetName("Buy one Get one half price"),
+            new TestCaseData(2, 0.5m,TestItem, 1.0m)
+                .SetName("Buy one Get one free")
+        };
+    }
+}

--- a/src/GroceryCo.Checkout/GroceryCo.Checkout.csproj
+++ b/src/GroceryCo.Checkout/GroceryCo.Checkout.csproj
@@ -50,8 +50,14 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Model\FixedPricePromotion.cs" />
     <Compile Include="Model\GroceryItem.cs" />
     <Compile Include="Model\GroceryItemLoader.cs" />
+    <Compile Include="Model\IPromotion.cs" />
+    <Compile Include="Model\PromotionLoader.cs" />
+    <Compile Include="Model\PromotionPoco.cs" />
+    <Compile Include="Model\PromotionType.cs" />
+    <Compile Include="Model\RelativePricePromotion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/GroceryCo.Checkout/Model/FixedPricePromotion.cs
+++ b/src/GroceryCo.Checkout/Model/FixedPricePromotion.cs
@@ -3,6 +3,10 @@ using System.Security.Policy;
 
 namespace GroceryCo.Checkout.Model
 {
+    /// <summary>
+    /// A promotion representing a fixed price for a quantity of <see cref="GroceryItem"/>
+    /// for example a promotion which may be stated as "Three for $2.00"
+    /// </summary>
     internal sealed class FixedPricePromotion : IPromotion
     {
         /// <summary>

--- a/src/GroceryCo.Checkout/Model/FixedPricePromotion.cs
+++ b/src/GroceryCo.Checkout/Model/FixedPricePromotion.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Security.Policy;
+
+namespace GroceryCo.Checkout.Model
+{
+    internal sealed class FixedPricePromotion : IPromotion
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="quantity">The quantity of item which qualifies for the promotion</param>
+        /// <param name="price">The fixed price for the specified quantity of items</param>
+        public FixedPricePromotion(int quantity, decimal price)
+        {
+            Quantity = quantity;
+            Price = price;
+        }
+
+
+        /// <summary>
+        /// The price for the specified quantity of the specified item
+        /// </summary>
+        public decimal Price { get; }
+
+
+        /// <summary>
+        /// The quantity of items for which the promotion is valid
+        /// </summary>
+        public int Quantity { get; }
+    }
+}

--- a/src/GroceryCo.Checkout/Model/IPromotion.cs
+++ b/src/GroceryCo.Checkout/Model/IPromotion.cs
@@ -1,0 +1,20 @@
+﻿namespace GroceryCo.Checkout.Model
+{
+    /// <summary>
+    /// Represents a promotion offered on a <see cref="GroceryItem"/>
+    /// </summary>
+    internal interface IPromotion
+    {
+        /// <summary>
+        /// The quantity of the specified item which qualifies
+        /// the customer for the promotion
+        /// </summary>
+        int Quantity { get; }
+
+
+        /// <summary>
+        /// The computed total price of Quantity of the specified item
+        /// </summary>
+        decimal Price { get; }
+    }
+}

--- a/src/GroceryCo.Checkout/Model/PromotionLoader.cs
+++ b/src/GroceryCo.Checkout/Model/PromotionLoader.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+
+namespace GroceryCo.Checkout.Model
+{
+    /// <summary>
+    /// Loads promotions from a JSON representation
+    /// </summary>
+    internal static class PromotionLoader
+    {
+        /// <summary>
+        /// Loads all promotions from the given JSON text
+        /// </summary>
+        /// <param name="jsonPromotions">The JSON representation of all stock promotions</param>
+        /// <param name="stockItems">A dictionary of all the unique <see cref="GroceryItem"/> in the store</param>
+        /// <returns></returns>
+        public static IEnumerable<IPromotion> Load(string jsonPromotions, IDictionary<string, GroceryItem> stockItems)
+        {
+            var promotions = JsonConvert.DeserializeObject<PromotionPoco[]>(jsonPromotions);
+
+            Func<PromotionPoco, IPromotion> promotionFactory = p =>
+            {
+                switch (p.PromotionType)
+                {
+                    case PromotionType.Fixed:
+                        return new FixedPricePromotion(p.Quantity, p.Rate);
+
+                    case PromotionType.Relative:
+
+                        if (!stockItems.ContainsKey(p.ItemId))
+                        {
+                            throw new InvalidOperationException($"The GroceryItem {p.ItemId} is not listed in stock");
+                        }
+
+                        return new RelativePricePromotion(stockItems[p.ItemId], p.Quantity, p.Rate);
+                    default:
+                        throw new ArgumentOutOfRangeException();
+                }
+            };
+
+            return promotions.Select(promotionFactory);
+        }
+    }
+}

--- a/src/GroceryCo.Checkout/Model/PromotionPoco.cs
+++ b/src/GroceryCo.Checkout/Model/PromotionPoco.cs
@@ -1,0 +1,31 @@
+﻿namespace GroceryCo.Checkout.Model
+{
+    /// <summary>
+    /// Poco class for the an item promotion
+    /// </summary>
+    internal sealed class PromotionPoco
+    {
+        /// <summary>
+        /// The quantity of <see cref="GroceryItem"/> required to qualify for the promotion
+        /// </summary>
+        public int Quantity { get; set; }
+
+
+        /// <summary>
+        /// The Id of the item to which the promotion applies
+        /// </summary>
+        public string ItemId { get; set; }
+
+
+        /// <summary>
+        /// The price of Quantity items given the prevailing promotion type
+        /// </summary>
+        public decimal Rate { get; set; }
+
+
+        /// <summary>
+        /// The <see cref="PromotionType"/> (fixed or variable) of the given promotion
+        /// </summary>
+        public PromotionType PromotionType { get; set; }
+    }
+}

--- a/src/GroceryCo.Checkout/Model/PromotionType.cs
+++ b/src/GroceryCo.Checkout/Model/PromotionType.cs
@@ -1,0 +1,12 @@
+﻿namespace GroceryCo.Checkout.Model
+{
+    /// <summary>
+    /// Describes whether a promotion offers a fixed price per quantity
+    /// of item or a price relative to the item price
+    /// </summary>
+    internal enum PromotionType
+    {
+        Fixed,
+        Relative
+    }
+}

--- a/src/GroceryCo.Checkout/Model/RelativePricePromotion.cs
+++ b/src/GroceryCo.Checkout/Model/RelativePricePromotion.cs
@@ -3,6 +3,8 @@
     /// <summary>
     /// Represents a promotion where the total price of a given
     /// quantity of items is a function of that quantity and price of the item
+    /// For example "Buy one get one free" indicates that if you buy two items
+    /// the cost will be 50% of the expected total.
     /// </summary>
     internal sealed class RelativePricePromotion : IPromotion
     {
@@ -18,6 +20,7 @@
             _rate = rate;
             Item = groceryItem;
         }
+
 
         /// <summary>
         /// The item under promotion

--- a/src/GroceryCo.Checkout/Model/RelativePricePromotion.cs
+++ b/src/GroceryCo.Checkout/Model/RelativePricePromotion.cs
@@ -1,0 +1,45 @@
+﻿namespace GroceryCo.Checkout.Model
+{
+    /// <summary>
+    /// Represents a promotion where the total price of a given
+    /// quantity of items is a function of that quantity and price of the item
+    /// </summary>
+    internal sealed class RelativePricePromotion : IPromotion
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="groceryItem">The <see cref="GroceryItem"/> for which the promotion isvalid</param>
+        /// <param name="quantity">The quantity of item which qualifies for the promotion</param>
+        /// <param name="rate">The percentage of the item price to be computed</param>
+        public RelativePricePromotion(GroceryItem groceryItem, int quantity, decimal rate)
+        {
+            Quantity = quantity;
+            _rate = rate;
+            Item = groceryItem;
+        }
+
+        /// <summary>
+        /// The item under promotion
+        /// </summary>
+        public GroceryItem Item { get; set; }
+
+
+        /// <summary>
+        /// The total discounted price of for the specified quantity of items
+        /// </summary>
+        public decimal Price => decimal.Round(Quantity * Item.Price * _rate, 2);
+
+
+        /// <summary>
+        /// The percentage of the total price for each item in this promotion
+        /// </summary>
+        private readonly decimal _rate;
+
+
+        /// <summary>
+        /// The quantity of items for which the promotion is valid
+        /// </summary>
+        public int Quantity { get; }
+    }
+}


### PR DESCRIPTION
Add a class to represent an item promotion.

The class should offer fixed or variable promotions where a fixed promotion is a fixed price for a quantity of identical items, where a variable price applies a percentage discount for a given quantity of items.