### PR TITLE
Implement Greedy checkout algorithm

### DIFF
--- a/src/GroceryCo.Checkout.Tests/CashRegister/CashRegisterTests.cs
+++ b/src/GroceryCo.Checkout.Tests/CashRegister/CashRegisterTests.cs
@@ -6,7 +6,7 @@ using NUnit.Framework;
 namespace GroceryCo.Checkout.Tests.CashRegister
 {
     /// <summary>
-    /// Test fixture for the <see cref="CashRegister"/> class including some common scenarios
+    /// Test fixture for the <see cref="CashRegister"/> class covering some common scenarios
     /// </summary>
     internal static class CashRegisterTests
     {
@@ -55,7 +55,6 @@ namespace GroceryCo.Checkout.Tests.CashRegister
             IEnumerable<ReceiptEntry> expectedReceiptEntreEntries)
         {
             // Arrange
-
             var items = GetItems(itemId, quantity, unitPrice).ToList();
 
             var register = new Checkout.CashRegister.CashRegister(promotions);
@@ -79,16 +78,32 @@ namespace GroceryCo.Checkout.Tests.CashRegister
                 1,
                 1.0m,
                 new IPromotion[] {new FixedPricePromotion("Apples", 3, 2.0m)},
-                new [] {new ReceiptEntry(1, "Apples", 1.0m, 1.0m, false)})
+                new [] {new ReceiptEntry(1, "Apples", 1.0m, 1.0m)})
             .SetName("One apple with a '3 for $2' promotion"),
+
+             new TestCaseData(
+                "Apples",
+                1,
+                1.0m,
+                new IPromotion[] {new RelativePricePromotion(GetItem("Apples", 1), 2, 0.5m)},
+                new [] {new ReceiptEntry(1, "Apples", 1.0m, 1.0m)})
+            .SetName("One apple with a 'buy one get one free' promotion"),
 
             new TestCaseData(
                 "Apples",
                 2,
                 1.0m,
                 new IPromotion[] {new FixedPricePromotion("Apples", 3, 2.0m)},
-                new [] {new ReceiptEntry(2, "Apples", 1.0m, 2.0m, false)})
+                new [] {new ReceiptEntry(2, "Apples", 1.0m, 2.0m)})
             .SetName("Two apples with a '3 for $2' promotion"),
+
+            new TestCaseData(
+                "Apples",
+                2,
+                1.0m,
+                new IPromotion[] {new RelativePricePromotion(GetItem("Apples", 1), 2, 0.5m)},
+                new [] {new ReceiptEntry(2, "Apples", 0.5m, 1.0m, true)})
+            .SetName("Two apples with a 'buy one get one free' promotion"),
 
              new TestCaseData(
                 "Apples",
@@ -106,7 +121,7 @@ namespace GroceryCo.Checkout.Tests.CashRegister
                 new []
                 {
                     new ReceiptEntry(3, "Apples", 0.67m, 2.0m, true),
-                    new ReceiptEntry(1, "Apples", 1.0m, 1.0m, false)
+                    new ReceiptEntry(1, "Apples", 1.0m, 1.0m)
                 })
             .SetName("Four apples with a '3 for $2' promotion")
         };
@@ -123,8 +138,20 @@ namespace GroceryCo.Checkout.Tests.CashRegister
         {
             for (var i = 0; i< quantity; i++)
             {
-                yield return new GroceryItem {Id = itemId, Price = unitPrice};
+                yield return GetItem(itemId, unitPrice);
             }
+        }
+
+
+        /// <summary>
+        /// Utility method for generating a single <see cref="GroceryItem"/>
+        /// </summary>
+        /// <param name="itemId">The id of the item to create</param>
+        /// <param name="unitPrice">The unit cost of each item</param>
+        /// <returns></returns>
+        private static GroceryItem GetItem(string itemId, decimal unitPrice)
+        {
+            return new GroceryItem { Id = itemId, Price = unitPrice };
         }
     }
 }

--- a/src/GroceryCo.Checkout.Tests/CashRegister/CashRegisterTests.cs
+++ b/src/GroceryCo.Checkout.Tests/CashRegister/CashRegisterTests.cs
@@ -1,0 +1,130 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using GroceryCo.Checkout.Model;
+using NUnit.Framework;
+
+namespace GroceryCo.Checkout.Tests.CashRegister
+{
+    /// <summary>
+    /// Test fixture for the <see cref="CashRegister"/> class including some common scenarios
+    /// </summary>
+    internal static class CashRegisterTests
+    {
+        [Test]
+        public static void Process_MultipleItemTypesNoPromotions_CorrectReceiptEntriesMade()
+        {
+            // Arrange
+            var register = new Checkout.CashRegister.CashRegister(Enumerable.Empty<IPromotion>());
+            var groceryItems = new[]
+            {
+                new GroceryItem {Id = "Apples", Price = 1.0m},
+                new GroceryItem {Id = "Apples", Price = 1.0m},
+                new GroceryItem {Id = "Oranges", Price = 2.0m},
+                new GroceryItem {Id = "Oranges", Price = 2.0m},
+            };
+
+            // Act
+            var receiptEntries = register.Process(groceryItems).ToArray();
+
+            // Assert
+            Assert.That(receiptEntries.Count(), Is.EqualTo(2));
+
+            //Test the receipt entry for apples
+            var applesEntry = receiptEntries.First(e => e.ItemDescription == "Apples");
+            Assert.That(applesEntry.Quantity, Is.EqualTo(2));
+            Assert.That(applesEntry.UnitPrice, Is.EqualTo(1.0m));
+            Assert.That(applesEntry.TotalPrice, Is.EqualTo(2.0m));
+            Assert.That(applesEntry.Promotion, Is.False);
+
+            //Test the receipt entry for oranges
+            var orangesEntry = receiptEntries.First(e => e.ItemDescription == "Oranges");
+            Assert.That(orangesEntry.Quantity, Is.EqualTo(2));
+            Assert.That(orangesEntry.UnitPrice, Is.EqualTo(2.0m));
+            Assert.That(orangesEntry.TotalPrice, Is.EqualTo(4.0m));
+            Assert.That(orangesEntry.Promotion, Is.False);
+        }
+
+
+
+        [TestCaseSource(nameof(TestData))]
+        public static void Process_OneItemTypeOnePromotion_CorrectReceiptEntriesMade(
+            string itemId,
+            int quantity,
+            decimal unitPrice,
+            IEnumerable<IPromotion> promotions,
+            IEnumerable<ReceiptEntry> expectedReceiptEntreEntries)
+        {
+            // Arrange
+
+            var items = GetItems(itemId, quantity, unitPrice).ToList();
+
+            var register = new Checkout.CashRegister.CashRegister(promotions);
+
+            // Act
+            var actualReceiptEntries = register.Process(items).ToArray();
+
+            // Assert
+            CollectionAssert.AreEquivalent(actualReceiptEntries, expectedReceiptEntreEntries);
+        }
+
+
+        /// <summary>
+        /// Test data to exercise the CashRegister class wth various promotional offers
+        /// </summary>
+        private static readonly TestCaseData[] TestData = new[]
+        {
+            
+            new TestCaseData(
+                "Apples",
+                1,
+                1.0m,
+                new IPromotion[] {new FixedPricePromotion("Apples", 3, 2.0m)},
+                new [] {new ReceiptEntry(1, "Apples", 1.0m, 1.0m, false)})
+            .SetName("One apple with a '3 for $2' promotion"),
+
+            new TestCaseData(
+                "Apples",
+                2,
+                1.0m,
+                new IPromotion[] {new FixedPricePromotion("Apples", 3, 2.0m)},
+                new [] {new ReceiptEntry(2, "Apples", 1.0m, 2.0m, false)})
+            .SetName("Two apples with a '3 for $2' promotion"),
+
+             new TestCaseData(
+                "Apples",
+                3,
+                1.0m,
+                new IPromotion[] {new FixedPricePromotion("Apples", 3, 2.0m)},
+                new [] {new ReceiptEntry(3, "Apples", 0.67m, 2.0m, true)})
+            .SetName("Three apples with a '3 for $2' promotion"),
+
+             new TestCaseData(
+                "Apples",
+                4,
+                1.0m,
+                new IPromotion[] {new FixedPricePromotion("Apples", 3, 2.0m)},
+                new []
+                {
+                    new ReceiptEntry(3, "Apples", 0.67m, 2.0m, true),
+                    new ReceiptEntry(1, "Apples", 1.0m, 1.0m, false)
+                })
+            .SetName("Four apples with a '3 for $2' promotion")
+        };
+
+
+        /// <summary>
+        /// Utility method for creating test data
+        /// </summary>
+        /// <param name="itemId">The id of the item to create</param>
+        /// <param name="quantity">The quanitiy of items to create</param>
+        /// <param name="unitPrice">The unit cost of each item</param>
+        /// <returns>A sequence of <see cref="GroceryItem"/></returns>
+        private static IEnumerable<GroceryItem> GetItems(string itemId, int quantity, decimal unitPrice)
+        {
+            for (var i = 0; i< quantity; i++)
+            {
+                yield return new GroceryItem {Id = itemId, Price = unitPrice};
+            }
+        }
+    }
+}

--- a/src/GroceryCo.Checkout.Tests/GroceryCo.Checkout.Tests.csproj
+++ b/src/GroceryCo.Checkout.Tests/GroceryCo.Checkout.Tests.csproj
@@ -54,6 +54,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CashRegister\CashRegisterTests.cs" />
     <Compile Include="Model\FixedPricePromotionTests.cs" />
     <Compile Include="Model\GroceryItemLoaderTests.cs" />
     <Compile Include="Model\PromotionLoaderTests.cs" />

--- a/src/GroceryCo.Checkout.Tests/Model/FixedPricePromotionTests.cs
+++ b/src/GroceryCo.Checkout.Tests/Model/FixedPricePromotionTests.cs
@@ -6,24 +6,28 @@ namespace GroceryCo.Checkout.Tests.Model
     internal static class FixedPricePromotionTests
     {
         [TestCaseSource(nameof(TestCases))]
-        public static void Price_VariousScenarios_PriceComputedCorrectly(int quantity, decimal rate)
+        public static void Price_VariousScenarios_PriceComputedCorrectly(int quantity, decimal rate, decimal expectedUnitPrice, string expectedItemId)
         {
             // Arrange
-            var promotion = new FixedPricePromotion(quantity, rate);
+            var promotion = new FixedPricePromotion(expectedItemId, quantity, rate);
 
             // Act
             var actualPrice = promotion.Price;
+            var actualUnitPrice = promotion.UnitPrice;
+            var actualItemId = promotion.ItemId;
 
             //Assert
             Assert.That(actualPrice, Is.EqualTo(rate));
+            Assert.That(actualUnitPrice, Is.EqualTo(expectedUnitPrice));
+            Assert.That(actualItemId, Is.EqualTo(expectedItemId));
         }
 
 
         private static readonly TestCaseData[] TestCases = new[]
         {
-            new TestCaseData(2, 3.0m)
+            new TestCaseData(2, 3.0m, 1.5m, "foo")
                 .SetName("Two for $3"),
-            new TestCaseData(3, 3.0m)
+            new TestCaseData(3, 3.0m, 1.0m, "bar")
                 .SetName("Three for $3")
         };
     }

--- a/src/GroceryCo.Checkout.Tests/Model/RelativePricePromotionTests.cs
+++ b/src/GroceryCo.Checkout.Tests/Model/RelativePricePromotionTests.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections;
-using System.Collections.Generic;
-using GroceryCo.Checkout.Model;
+﻿using GroceryCo.Checkout.Model;
 using NUnit.Framework;
 
 namespace GroceryCo.Checkout.Tests.Model
@@ -8,16 +6,26 @@ namespace GroceryCo.Checkout.Tests.Model
     internal static class RelativePricePromotionTests
     {
         [TestCaseSource(nameof(TestCases))]
-        public static void Price_VariousScenarios_TotalPriceComputedCorrectly(int quantity, decimal rate, GroceryItem groceryItem, decimal expectedPrice)
+        public static void Price_VariousScenarios_TotalPriceComputedCorrectly(
+            int quantity,
+            decimal rate,
+            GroceryItem groceryItem,
+            decimal expectedPrice,
+            decimal expectedUnitPrice,
+            string expectedItemId)
         {
             // Arrange
             var promotion = new RelativePricePromotion(groceryItem, quantity, rate);
 
             // Act
             var actualPrice = promotion.Price;
+            var actualUnitPrice = promotion.UnitPrice;
+            var actualItemId = promotion.ItemId;
 
             // Assert
             Assert.That(actualPrice, Is.EqualTo(expectedPrice));
+            Assert.That(actualUnitPrice, Is.EqualTo(expectedUnitPrice));
+            Assert.That(actualItemId, Is.EqualTo(expectedItemId));
         }
 
 
@@ -26,9 +34,9 @@ namespace GroceryCo.Checkout.Tests.Model
 
         private static readonly TestCaseData[] TestCases = new []
         {
-            new TestCaseData(2, 0.75m,TestItem, 1.5m)
+            new TestCaseData(2, 0.75m, TestItem, 1.5m, 0.75m, TestItem.Id)
                 .SetName("Buy one Get one half price"),
-            new TestCaseData(2, 0.5m,TestItem, 1.0m)
+            new TestCaseData(2, 0.5m, TestItem, 1.0m, 0.5m, TestItem.Id)
                 .SetName("Buy one Get one free")
         };
     }

--- a/src/GroceryCo.Checkout/CashRegister/CashRegister.cs
+++ b/src/GroceryCo.Checkout/CashRegister/CashRegister.cs
@@ -1,0 +1,73 @@
+using System.Collections.Generic;
+using System.Linq;
+using GroceryCo.Checkout.Model;
+
+namespace GroceryCo.Checkout.CashRegister
+{
+    /// <summary>
+    /// Implementation of a checkout algorithm using a Greedy approach
+    /// </summary>
+    public sealed class CashRegister
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="promotions">A sequence of all the promotions offered by the store</param>
+        public CashRegister(IEnumerable<IPromotion> promotions)
+        {
+            _promotions = promotions ?? Enumerable.Empty<IPromotion>();
+        }
+
+
+        /// <summary>
+        /// Processes the content of the basket and generates entries to be included
+        /// on a receipt. 
+        /// </summary>
+        /// <param name="basketContent">the sequence of <see cref="GroceryItem"/> objects to be processed</param>
+        /// <returns>A sequence of <see cref="ReceiptEntry"/> objects for inclusion in a receipt</returns>
+        public IEnumerable<ReceiptEntry> Process(IEnumerable<GroceryItem> basketContent)
+        {
+            var result = new List<ReceiptEntry>();
+
+            // Group the items in the basket and count how many there
+            // are of each
+            var groupedItems = basketContent.GroupBy(i => i.Id);
+
+            // process each type of item individually
+            foreach (var itemGroup in groupedItems)
+            {
+                // establish promotions apply to the given Item
+                // And sort them by unit price.
+                var relevantPromotions = _promotions
+                    .Where(p => p.ItemId == itemGroup.Key)
+                    .OrderBy(p => p.UnitPrice);
+
+                var itemsLeft = itemGroup.Count();
+
+                // itterate through the applicable promotions
+                // using the ones with most value for money (i.e lowest UnitPrice)
+                // as often as possible.
+                foreach (var promotion in relevantPromotions)
+                {
+                    while (itemsLeft >= promotion.Quantity)
+                    {
+                        result.Add(new ReceiptEntry(promotion.Quantity, itemGroup.Key, promotion.UnitPrice, promotion.Price, true));
+                        itemsLeft = itemsLeft - promotion.Quantity;
+                    }
+                }
+
+                // any remaining items do not qualify for a promotion
+                // and must be paid for in full
+                if (itemsLeft == 0) continue;
+
+                var groceryItem = itemGroup.First();
+                result.Add(new ReceiptEntry(itemsLeft, groceryItem.Id, groceryItem.Price, groceryItem.Price * itemsLeft));
+            }
+
+            return result;
+        }
+
+
+        private readonly IEnumerable<IPromotion> _promotions;
+    }
+}

--- a/src/GroceryCo.Checkout/GroceryCo.Checkout.csproj
+++ b/src/GroceryCo.Checkout/GroceryCo.Checkout.csproj
@@ -50,6 +50,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CashRegister\CashRegister.cs" />
     <Compile Include="Model\FixedPricePromotion.cs" />
     <Compile Include="Model\GroceryItem.cs" />
     <Compile Include="Model\GroceryItemLoader.cs" />
@@ -57,6 +58,7 @@
     <Compile Include="Model\PromotionLoader.cs" />
     <Compile Include="Model\PromotionPoco.cs" />
     <Compile Include="Model\PromotionType.cs" />
+    <Compile Include="Model\ReceiptEntry.cs" />
     <Compile Include="Model\RelativePricePromotion.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -64,6 +66,7 @@
     <None Include="GroceryCo.snk" />
     <None Include="packages.config" />
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/GroceryCo.Checkout/Model/FixedPricePromotion.cs
+++ b/src/GroceryCo.Checkout/Model/FixedPricePromotion.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Security.Policy;
-
-namespace GroceryCo.Checkout.Model
+﻿namespace GroceryCo.Checkout.Model
 {
     /// <summary>
     /// A promotion representing a fixed price for a quantity of <see cref="GroceryItem"/>
@@ -12,13 +9,27 @@ namespace GroceryCo.Checkout.Model
         /// <summary>
         /// Constructor
         /// </summary>
+        /// <param name="itemId">The Id of the <see cref="GroceryItem"/> to which the promotion is being offered</param>
         /// <param name="quantity">The quantity of item which qualifies for the promotion</param>
         /// <param name="price">The fixed price for the specified quantity of items</param>
-        public FixedPricePromotion(int quantity, decimal price)
+        public FixedPricePromotion(string itemId, int quantity, decimal price)
         {
+            ItemId = itemId;
             Quantity = quantity;
             Price = price;
         }
+
+
+        /// <summary>
+        /// The Id of the <see cref="GroceryItem"/> to which the promotion is being offered
+        /// </summary>
+        public string ItemId { get; }
+
+
+        /// <summary>
+        /// The quantity of items for which the promotion is valid
+        /// </summary>
+        public int Quantity { get; }
 
 
         /// <summary>
@@ -28,8 +39,8 @@ namespace GroceryCo.Checkout.Model
 
 
         /// <summary>
-        /// The quantity of items for which the promotion is valid
+        /// The price of one <see cref="GroceryItem"/> under the terms of the promotion
         /// </summary>
-        public int Quantity { get; }
+        public decimal UnitPrice => decimal.Round(Price/Quantity, 2);
     }
 }

--- a/src/GroceryCo.Checkout/Model/GroceryItem.cs
+++ b/src/GroceryCo.Checkout/Model/GroceryItem.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Poco for a grocery item
     /// </summary>
-    internal sealed class GroceryItem
+    public sealed class GroceryItem
     {
         /// <summary>
         /// The unique ID for the grocery item

--- a/src/GroceryCo.Checkout/Model/IPromotion.cs
+++ b/src/GroceryCo.Checkout/Model/IPromotion.cs
@@ -3,8 +3,14 @@
     /// <summary>
     /// Represents a promotion offered on a <see cref="GroceryItem"/>
     /// </summary>
-    internal interface IPromotion
+    public interface IPromotion
     {
+        /// <summary>
+        /// The Id of the <see cref="GroceryItem"/> to which the promotion applies
+        /// </summary>
+        string ItemId { get; }
+
+
         /// <summary>
         /// The quantity of the specified item which qualifies
         /// the customer for the promotion
@@ -13,8 +19,14 @@
 
 
         /// <summary>
-        /// The computed total price of Quantity of the specified item
+        /// The computed total price of Quantity units of the specified item
         /// </summary>
         decimal Price { get; }
+
+
+        /// <summary>
+        /// The price of one unit of <see cref="GroceryItem"/> accoriding to teh given promotion
+        /// </summary>
+        decimal UnitPrice { get; }
     }
 }

--- a/src/GroceryCo.Checkout/Model/PromotionLoader.cs
+++ b/src/GroceryCo.Checkout/Model/PromotionLoader.cs
@@ -15,26 +15,29 @@ namespace GroceryCo.Checkout.Model
         /// </summary>
         /// <param name="jsonPromotions">The JSON representation of all stock promotions</param>
         /// <param name="stockItems">A dictionary of all the unique <see cref="GroceryItem"/> in the store</param>
-        /// <returns></returns>
+        /// <returns>A sequence of promotions thatthe store is currently offering</returns>
         public static IEnumerable<IPromotion> Load(string jsonPromotions, IDictionary<string, GroceryItem> stockItems)
         {
             var promotions = JsonConvert.DeserializeObject<PromotionPoco[]>(jsonPromotions);
 
             Func<PromotionPoco, IPromotion> promotionFactory = p =>
             {
+                // Determine that the item is actually available
+                if (!stockItems.ContainsKey(p.ItemId))
+                {
+                    throw new InvalidOperationException($"The GroceryItem {p.ItemId} is not listed in stock");
+                }
+
+                var groceryItem = stockItems[p.ItemId];
+
                 switch (p.PromotionType)
                 {
                     case PromotionType.Fixed:
-                        return new FixedPricePromotion(p.Quantity, p.Rate);
+                        return new FixedPricePromotion(groceryItem.Id, p.Quantity, p.Rate);
 
                     case PromotionType.Relative:
+                        return new RelativePricePromotion(groceryItem, p.Quantity, p.Rate);
 
-                        if (!stockItems.ContainsKey(p.ItemId))
-                        {
-                            throw new InvalidOperationException($"The GroceryItem {p.ItemId} is not listed in stock");
-                        }
-
-                        return new RelativePricePromotion(stockItems[p.ItemId], p.Quantity, p.Rate);
                     default:
                         throw new ArgumentOutOfRangeException();
                 }

--- a/src/GroceryCo.Checkout/Model/ReceiptEntry.cs
+++ b/src/GroceryCo.Checkout/Model/ReceiptEntry.cs
@@ -1,0 +1,79 @@
+﻿namespace GroceryCo.Checkout.Model
+{
+    /// <summary>
+    /// Represents an entry to be included on the receipt
+    /// </summary>
+    public sealed class ReceiptEntry
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="quantity">The total quantity of items purchased</param>
+        /// <param name="itemDescription">The description of the item</param>
+        /// <param name="unitPrice">The unit price of each item</param>
+        /// <param name="totalPrice">The total price of all the items</param>
+        /// <param name="promotion">True if the price was the result of a promotion</param>
+        public ReceiptEntry(int quantity, string itemDescription, decimal unitPrice, decimal totalPrice, bool promotion = false)
+        {
+            Quantity = quantity;
+            ItemDescription = itemDescription;
+            UnitPrice = unitPrice;
+            TotalPrice = totalPrice;
+            Promotion = promotion;
+        }
+
+
+        /// <summary>
+        /// The total quantity of items purchased
+        /// </summary>
+        public int Quantity { get; }
+
+
+        /// <summary>
+        /// The description of the item
+        /// </summary>
+        public string ItemDescription { get; }
+
+
+        /// <summary>
+        /// The unit price of each item
+        /// </summary>
+        public decimal UnitPrice { get; }
+
+
+        /// <summary>
+        /// The total price of all the items
+        /// </summary>
+        public decimal TotalPrice { get; }
+
+
+        /// <summary>
+        /// True if the price was the result of a promotion
+        /// </summary>
+        public bool Promotion { get; }
+
+
+        public override bool Equals(object obj)
+        {
+            return obj is ReceiptEntry ? this.Equals((ReceiptEntry)obj) : base.Equals(obj);
+        }
+
+        private bool Equals(ReceiptEntry other)
+        {
+            return Quantity == other.Quantity && string.Equals(ItemDescription, other.ItemDescription) && UnitPrice == other.UnitPrice && TotalPrice == other.TotalPrice && Promotion == other.Promotion;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                var hashCode = Quantity;
+                hashCode = (hashCode*397) ^ (ItemDescription != null ? ItemDescription.GetHashCode() : 0);
+                hashCode = (hashCode*397) ^ UnitPrice.GetHashCode();
+                hashCode = (hashCode*397) ^ TotalPrice.GetHashCode();
+                hashCode = (hashCode*397) ^ Promotion.GetHashCode();
+                return hashCode;
+            }
+        }
+    }
+}

--- a/src/GroceryCo.Checkout/Model/RelativePricePromotion.cs
+++ b/src/GroceryCo.Checkout/Model/RelativePricePromotion.cs
@@ -29,20 +29,32 @@
 
 
         /// <summary>
-        /// The total discounted price of for the specified quantity of items
+        /// The Id of the <see cref="GroceryItem"/> to which this promotion applies
         /// </summary>
-        public decimal Price => decimal.Round(Quantity * Item.Price * _rate, 2);
-
-
-        /// <summary>
-        /// The percentage of the total price for each item in this promotion
-        /// </summary>
-        private readonly decimal _rate;
+        public string ItemId => Item.Id;
 
 
         /// <summary>
         /// The quantity of items for which the promotion is valid
         /// </summary>
         public int Quantity { get; }
+
+
+        /// <summary>
+        /// The total discounted price of for the specified quantity of items
+        /// </summary>
+        public decimal Price => decimal.Round(Quantity * Item.Price * _rate, 2);
+
+
+        /// <summary>
+        /// The price of one <see cref="GroceryItem"/> under the terms of the promotion
+        /// </summary>
+        public decimal UnitPrice => decimal.Round(Price / Quantity, 2);
+
+
+        /// <summary>
+        /// The percentage of the total price for each item in this promotion
+        /// </summary>
+        private readonly decimal _rate;
     }
 }


### PR DESCRIPTION
Implement the greedy algorithm

- Sort promotions by value for money using a seed of $1

- For each item, test whether each promotion (in order of value for money is triggered for the given quantity. If so Use that promotion and subtract the quantity from the remaining items.

- Repeat until no items are left